### PR TITLE
support wkhtmltopdf by avoiding ES2015 shorthand property names

### DIFF
--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -65,10 +65,10 @@
                 return word;
             }, 2),
             onBeforeElementHyphenation: setProp(function (element, lang) {
-                return {element, lang};
+                return {"element": element, "lang": lang};
             }, 2),
             onAfterElementHyphenation: setProp(function (element, lang) {
-                return {element, lang};
+                return {"element": element, "lang": lang};
             }, 2)
         });
 


### PR DESCRIPTION
Maybe someone else also needs it with old webkit versions.