### PR TITLE
feat: add support for shadowDOM

### DIFF
--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -145,6 +145,7 @@
             ["exceptions", new Map()],
             ["keepAlive", true],
             ["normalize", false],
+            ["processShadows", false],
             ["safeCopy", true],
             ["substitute", new Map()],
             ["timeout", 1000]
@@ -366,12 +367,27 @@
                     }
                 });
             }
-            if (parent === null) {
+
+            /**
+             * Searches the DOM for each sel
+             * @param {object} root The DOM root
+             */
+            function getElems(root) {
                 C.selectors.forEach((sel) => {
-                    w.document.querySelectorAll(sel).forEach((n) => {
+                    root.querySelectorAll(sel).forEach((n) => {
                         processElements(n, getLang(n, true), sel, false);
                     });
                 });
+            }
+            if (parent === null) {
+                if (C.processShadows) {
+                    w.document.querySelectorAll("*").forEach((m) => {
+                        if (m.shadowRoot) {
+                            getElems(m.shadowRoot);
+                        }
+                    });
+                }
+                getElems(w.document);
             } else {
                 processElements(parent, getLang(parent, true), selector);
             }

--- a/docs/Hyphenators.md
+++ b/docs/Hyphenators.md
@@ -96,8 +96,8 @@ Objects of type `HTMLElement` can be hyphenated with the `HTML`-hyphenator (`Hyp
 </script>
 <script src="./Hyphenopoly_Loader.js"></script>
 <script>
-    Hyphenopoly.hyphenators["HTML"].then((hyphenator_en) => {
-        hyphenator_en(document.getElementById("hyphenateme"));
+    Hyphenopoly.hyphenators.HTML.then((hyn) => {
+        hyn(document.getElementById("hyphenateme"));
     });
 </script>
 </head>
@@ -124,7 +124,7 @@ Instead of using `.then` on the Promises we could also use `async/await`:
 
 ````javascript
 async function runHyphenator(id) {
-    (await Hyphenopoly.hyphenators["HTML"])(document.getElementById(id));
+    (await Hyphenopoly.hyphenatorsHTML)(document.getElementById(id));
 }
 runHyphenator("hyphenateme");
 ````

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -9,6 +9,7 @@ These page documents the optional fields in `setup`:
     *   [hide](#hide)
     *   [keepAlive](#keepalive)
     *   [normalize](#normalize)
+    *   [processShadows](#processshadows)
     *   [safeCopy](#safecopy)
     *   [substitute](#substitute)
     *   [timeout](#timeout)
@@ -249,6 +250,26 @@ var Hyphenopoly = {
 The pattern files work with _precomposed_ characters. So an `Å` (LATIN CAPITAL LETTER A WITH RING ABOVE) must not be composed of `A` (LATIN CAPITAL LETTER A) and ` ̊` (COMBINING RING ABOVE) to be recognizable by hyphenation-engine.
 If the text contains _composed_ characters they must be normalized to _precomposed_ characters. If `normalize` is activated and the user agent supports `String.prototype.normalize()` this can happen automatically.
 Since this comes with a performance penalty it is deactivated by default and it's recommended to use _precomposed_ characters in HTML.
+
+### processShadows
+````
+type: boolean
+default: false
+````
+Configure if Hyphenopoly searches for given selectors in (open) shadowDOMs.
+````html
+<script>
+var Hyphenopoly = {
+    require: {...},
+    paths: {...},
+    setup: {
+        processShadows: true,
+        selectors: {...}
+    }
+};
+</script>
+````
+By default Hyphenopoly only searches for the given [selectors](./Global-Hyphenopoly-Object.md#selectors) in `window.document`. With this option set to true, Hyphenopoly also searches for the given selectors in Web Components (if accessible, i.e. `open`).
 
 ### safeCopy
 ````

--- a/testsuite/test47.html
+++ b/testsuite/test47.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>Test 047</title>
+        <script>
+            var Hyphenopoly = {
+                require: {
+                    "en-us": "FORCEHYPHENOPOLY",
+                    "de": "FORCEHYPHENOPOLY"
+                },
+                setup: {
+                    processShadows: true,
+                    selectors: {
+                        ".hyphenate": {
+                            hyphen: "•"
+                        }
+                    }
+                },
+                handleEvent: {
+                    hyphenopolyEnd: function (e) {
+                        assert();
+                    }
+                }
+            };
+            function assert() {
+                var tests = 1;
+                var i = 1;
+                var test = "";
+                var ref = "";
+                var result = true;
+                while (i <= tests) {
+                    test = document.getElementById("test" + i).shadowRoot.innerHTML;
+                    console.dir(test);
+                    ref = document.getElementById("ref" + i).innerHTML;
+                    if (test === ref) {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #d6ffd6\">" + i + " passed</p>";
+                        result = result && true;
+                    } else {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #ffd6d6\">" + i + " failed</p>";
+                        result = false;
+                    }
+                    i += 1;
+                }
+                if (parent != window) {
+                    parent.postMessage(JSON.stringify({
+                        desc: document.getElementById("desc").innerHTML,
+                        index: 47,
+                        result: (result ? "passed" : "failed")
+                    }), window.location.href);
+                }
+            }
+        </script>
+        <script src="../Hyphenopoly_Loader.js"></script>
+        <style type="text/css">
+            body {
+                width:50%;
+                margin-left:25%;
+                margin-right:25%;
+            }
+
+            .test {
+                background-color: #D8E2F9;
+            }
+            .ref {
+                background-color: #FEEFC0;
+            }
+
+            .hyphenate {
+                hyphens: auto;
+                -ms-hyphens: auto;
+                -moz-hyphens: auto;
+                -webkit-hyphens: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="navigate"><a href="index.html">&Larr;&nbsp;Index</a>&nbsp;|&nbsp;<a href="test46.html">&larr;&nbsp;Prev</a>&nbsp;|&nbsp;<a href="test48.html">Next&nbsp;&rarr;</a></div>
+
+        <h1>Test 047</h1>
+        <p id="desc">Test hyphenation in ShadowDOM</p>
+        <div id="result"></div>
+        <hr>
+
+        <div id="test1" class="test"></div>
+        <div id="ref1" class="ref">
+            <p lang="en-us" class="hyphenate">Hy•phen•ation</p>
+            <p lang="de" class="hyphenate">Sil•ben•tren•nung</p>
+        </div>
+
+        <template>
+            <p lang="en-us" class="hyphenate">Hyphenation</p>
+            <p lang="de" class="hyphenate">Silbentrennung</p>
+        </template>
+
+        <script>
+            var template = document.querySelector("template");
+            var host = document.querySelector("#test1");
+            var root = host.attachShadow({mode: 'open'});
+            root.appendChild(document.importNode(template.content, true));
+        </script>
+
+        <hr>
+        <div><span class="test">Test</span> <span class="ref">Ref</span></div>
+
+    </body>
+</html>

--- a/testsuite/testdriver.js
+++ b/testsuite/testdriver.js
@@ -50,7 +50,8 @@
         {"exec": true, "path": "test43.html"},
         {"exec": true, "path": "test44.html"},
         {"exec": true, "path": "test45.html"},
-        {"exec": true, "path": "test46.html"}
+        {"exec": true, "path": "test46.html"},
+        {"exec": true, "path": "test47.html"}
     ];
     var testframe = document.getElementById("testframe");
     var currentTest = 1;


### PR DESCRIPTION
Problem:
querySelectorAll doesn't find elements in shadowDOM.

Solution:
Implement option "processShadows" (default false) and search elements
in shadowRoot if set to true.

Notes:
Fixes #130, [skip travis-ci]