### PR TITLE
fix: retrieving maindir now works correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version History
 
+## Version 4.6.1 (2020-07-XX)
+### Fixed
+*   retrieving maindir now works correctly if the filename is mangled (#135)
+
 ## Version 4.6.0 (2020-06-29)
 ### Added
 *   support for hyphenating in shadowDOM (#131)

--- a/Hyphenopoly_Loader.js
+++ b/Hyphenopoly_Loader.js
@@ -69,7 +69,8 @@
      * These is an iife to keep complexity low.
      */
     (() => {
-        const maindir = d.currentScript.src.slice(0, -(scriptName.length));
+        const thisScript = d.currentScript.src;
+        const maindir = thisScript.slice(0, (thisScript.lastIndexOf("/") + 1));
         const patterndir = maindir + "patterns/";
         H.paths = setDefaults(H.paths, {
             maindir,

--- a/testsuite/test49.html
+++ b/testsuite/test49.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>Test 049</title>
+        <script>
+            var Hyphenopoly = {
+                require: {
+                    "hu": "FORCEHYPHENOPOLY"
+                },
+                setup: {
+                    selectors: {
+                        ".hyphenate": {
+                            hyphen: "•"
+                        }
+                    }
+                },
+                handleEvent: {
+                    hyphenopolyEnd: function (e) {
+                        assert();
+                    }
+                }
+            };
+            function assert() {
+                var tests = 1;
+                var i = 1;
+                var test = "";
+                var ref = "";
+                var result = true;
+                while (i <= tests) {
+                    test = document.getElementById("test" + i).innerHTML;
+                    ref = document.getElementById("ref" + i).innerHTML;
+                    if (test === ref) {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #d6ffd6\">" + i + " passed</p>";
+                        result = result && true;
+                    } else {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #ffd6d6\">" + i + " failed</p>";
+                        result = false;
+                    }
+                    i += 1;
+                }
+                if (parent != window) {
+                    parent.postMessage(JSON.stringify({
+                        desc: document.getElementById("desc").innerHTML,
+                        index: 49,
+                        result: (result ? "passed" : "failed")
+                    }), window.location.href);
+                }
+            }
+        </script>
+        <script src="../Hyphenopoly_Loader.js?var=12345"></script>
+        <style type="text/css">
+            body {
+                width:50%;
+                margin-left:25%;
+                margin-right:25%;
+            }
+
+            .test {
+                background-color: #D8E2F9;
+            }
+            .ref {
+                background-color: #FEEFC0;
+            }
+
+            .hyphenate {
+                hyphens: auto;
+                -ms-hyphens: auto;
+                -moz-hyphens: auto;
+                -webkit-hyphens: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="navigate"><a href="index.html">&Larr;&nbsp;Index</a>&nbsp;|&nbsp;<a href="test48.html">&larr;&nbsp;Prev</a>&nbsp;|&nbsp;<a href="test50.html">Next&nbsp;&rarr;</a></div>
+
+        <h1>Test 049</h1>
+        <p id="desc">Load Hyphenopoly_Loader.js with a GET-parameter</p>
+        <div id="result"></div>
+        <hr>
+        <p id="test1" class="test hyphenate" lang="hu">automatikusan</p>
+        <p id="ref1" class="ref" lang="hu">au•to•ma•ti•ku•san</p>
+
+        <hr>
+        <div><span class="test">Test</span> <span class="ref">Ref</span></div>
+
+    </body>
+</html>

--- a/testsuite/testdriver.js
+++ b/testsuite/testdriver.js
@@ -52,7 +52,8 @@
         {"exec": true, "path": "test45.html"},
         {"exec": true, "path": "test46.html"},
         {"exec": true, "path": "test47.html"},
-        {"exec": true, "path": "test48.html"}
+        {"exec": true, "path": "test48.html"},
+        {"exec": true, "path": "test49.html"}
     ];
     var testframe = document.getElementById("testframe");
     var currentTest = 1;


### PR DESCRIPTION
Problem:
Retrieving `maindir` doesn't work if the filename is changed.

Solution:
Slice until the lastIndexOf("/").

Notes:
This wil break if there are unescaped slashes in the GET-parameter!

Fixes #135, [skip travis-ci]