### PR TITLE
I139

### DIFF
--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -170,7 +170,8 @@
                         ["mixedCase", true],
                         ["orphanControl", 1],
                         ["rightmin", 0],
-                        ["rightminPerLang", 0]
+                        ["rightminPerLang", 0],
+                        ["smallWords", 0]
                     ]));
                     o.entries(selSettings).forEach(
                         ([selSetting, setVal]) => {
@@ -580,6 +581,17 @@
                         createOrphanController(sel)
                     );
                 }
+                if (selSettings.smallWords > 0) {
+                    const re = RegExp(`(?=(\\s\\S{1,${selSettings.smallWords}}\\s))`, "gu");
+                    const matches = [];
+                    tn.replace(re, (orig, $1) => {
+                        matches.push($1);
+                    });
+                    matches.forEach((m) => {
+                        tn = tn.replace(RegExp(`(\\s)${m.slice(1)}`), `$1${m.slice(1, -1)}\u00A0`);
+                    });
+                }
+
                 return tn;
             }
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -21,6 +21,7 @@ These page documents the optional fields in `setup`:
     *   [minWordLength](#minwordlength)
     *   [mixedCase](#mixedcase)
     *   [orphanControl](#orphancontrol)
+    *   [smallWords](#smallwords)
 
 ## Global Settings
 These settings apply to Hyphenopoly in general.
@@ -524,3 +525,36 @@ There are three stages:
 1.  allow orphans
 2.  don't hyphenate the last word of an element
 3.  don't hyphenate the last word of an element and replace the space before with a no-breaking space
+
+### smallWords
+````
+type: number
+default: 0
+````
+Prevent small words at the end of a line by replacing the space after them with a no-breaking space (nbsp / uc: 00A0)
+````html
+<script>
+var Hyphenopoly = {
+    require: {...},
+    paths: {...},
+    setup: {
+        selectors: {
+            ".hyphenate": {
+                smallWords: 1
+            }
+        }
+    }
+};
+</script>
+````
+The number defines what words are considered "small":
+
+`0`: no words are considered small.
+
+`1`: insert nbsp after single letter words (e.g. "I" or "a")
+
+`2`: insert nbsp after single and double letter words
+
+`3`: insert nbsp after words with 1, 2 or 3 letter
+
+and so on...

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -549,12 +549,11 @@ var Hyphenopoly = {
 ````
 The number defines what words are considered "small":
 
-`0`: no words are considered small.
-
-`1`: insert nbsp after single letter words (e.g. "I" or "a")
-
-`2`: insert nbsp after single and double letter words
-
-`3`: insert nbsp after words with 1, 2 or 3 letter
+| Number | Effect |
+|:------:| ------ |
+| `0`    | no words are considered small. |
+| `1`    | insert nbsp after single letter words (e.g. "I" or "a"). |
+| `2`    | insert nbsp after single and double letter words. |
+| `3`    | insert nbsp after words with 1, 2 or 3 letters. |
 
 and so on...

--- a/hyphenopoly.module.js
+++ b/hyphenopoly.module.js
@@ -526,6 +526,16 @@ function createTextHyphenator(lang) {
                 orphanController
             );
         }
+        if (H.c.smallWords > 0) {
+            const re = RegExp(`(?=(\\s\\S{1,${H.c.smallWords}}\\s))`, "gu");
+            const matches = [];
+            tn.replace(re, (orig, $1) => {
+                matches.push($1);
+            });
+            matches.forEach((m) => {
+                tn = tn.replace(RegExp(`(\\s)${m.slice(1)}`), `$1${m.slice(1, -1)}\u00A0`);
+            });
+        }
         return tn;
     });
 }
@@ -669,6 +679,7 @@ H.config = ((userConfig) => {
         ["require", []],
         ["rightmin", 0],
         ["rightminPerLang", new Map()],
+        ["smallWords", 0],
         ["substitute", new Map()],
         ["sync", false]
     ]));

--- a/test/configurations.js
+++ b/test/configurations.js
@@ -345,3 +345,37 @@ t.test("set options: orphanControl", function (t) {
     });
     t.end();
 });
+
+t.test("set options: smallWords", function (t) {
+    let H9Y = null;
+    t.beforeEach(function setup(done) {
+        H9Y = require("../hyphenopoly.module");
+        done();
+    });
+
+    t.afterEach(function tearDown(done) {
+        H9Y = null;
+        delete require.cache[require.resolve("../hyphenopoly.module")];
+        done();
+    });
+
+    t.test("smallWords: 1", async function (t) {
+        const hyphenator = await H9Y.config({
+            "hyphen": "•",
+            "require": ["en-us"],
+            "smallWords": 1
+        });
+        t.equal(hyphenator("Yesterday I saw a cat."), "Yes•ter•day I\u00A0saw a\u00A0cat.");
+        t.end();
+    });
+    t.test("smallWords: 2", async function (t) {
+        const hyphenator = await H9Y.config({
+            "hyphen": "•",
+            "require": ["en-us"],
+            "smallWords": 2
+        });
+        t.equal(hyphenator("Yesterday I saw a cat in my backyard."), "Yes•ter•day I\u00A0saw a\u00A0cat in\u00A0my\u00A0back•yard.");
+        t.end();
+    });
+    t.end();
+});

--- a/testsuite/test50.html
+++ b/testsuite/test50.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>Test 050</title>
+        <script>
+            var Hyphenopoly = {
+                require: {
+                    "en-us": "FORCEHYPHENOPOLY"
+                },
+                setup: {
+                    selectors: {
+                        ".hyphenate1": {
+                            smallWords: 1
+                        },
+                        ".hyphenate2": {
+                            smallWords: 2
+                        },
+                        ".hyphenate3": {
+                            smallWords: 3
+                        },
+                        ".hyphenate4": {
+                            smallWords: 0
+                        }
+                    }
+                },
+                handleEvent: {
+                    hyphenopolyEnd: function (e) {
+                        assert();
+                    }
+                }
+            };
+            function assert() {
+                var tests = 5;
+                var i = 1;
+                var test = "";
+                var ref = "";
+                var result = true;
+                while (i <= tests) {
+                    test = document.getElementById("test" + i).innerHTML;
+                    ref = document.getElementById("ref" + i).innerHTML;
+                    if (test === ref) {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #d6ffd6\">" + i + " passed</p>";
+                        result = result && true;
+                    } else {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #ffd6d6\">" + i + " failed</p>";
+                        result = false;
+                    }
+                    i += 1;
+                }
+                if (parent != window) {
+                    parent.postMessage(JSON.stringify({
+                        desc: document.getElementById("desc").innerHTML,
+                        index: 50,
+                        result: (result ? "passed" : "failed")
+                    }), window.location.href);
+                }
+            }
+        </script>
+        <script src="../Hyphenopoly_Loader.js?var=12345"></script>
+        <style type="text/css">
+            body {
+                width:50%;
+                margin-left:25%;
+                margin-right:25%;
+            }
+
+            .test {
+                background-color: #D8E2F9;
+                width: 12%;
+            }
+            .ref {
+                background-color: #FEEFC0;
+                width: 12%;
+            }
+
+            .hyphenate {
+                hyphens: auto;
+                -ms-hyphens: auto;
+                -moz-hyphens: auto;
+                -webkit-hyphens: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="navigate"><a href="index.html">&Larr;&nbsp;Index</a>&nbsp;|&nbsp;<a href="test49.html">&larr;&nbsp;Prev</a>&nbsp;|&nbsp;<a href="test51.html">Next&nbsp;&rarr;</a></div>
+
+        <h1>Test 050</h1>
+        <p id="desc">Do not wrap small words.</p>
+        <div id="result"></div>
+        <hr>
+        <p id="test1" class="test hyphenate1" lang="en-us">Yesterday I saw a brown cat in my backyard.</p>
+        <p id="ref1" class="ref" lang="en-us">Yes&shy;ter&shy;day I&nbsp;saw a&nbsp;brown cat in my back&shy;yard.</p>
+
+        <p id="test2" class="test hyphenate2" lang="en-us">Yesterday I saw a brown cat in my backyard.</p>
+        <p id="ref2" class="ref" lang="en-us">Yes&shy;ter&shy;day I&nbsp;saw a&nbsp;brown cat in&nbsp;my&nbsp;back&shy;yard.</p>
+
+        <p id="test3" class="test hyphenate3" lang="en-us">Yesterday I saw a brown cat in my backyard.</p>
+        <p id="ref3" class="ref" lang="en-us">Yes&shy;ter&shy;day I&nbsp;saw&nbsp;a&nbsp;brown cat&nbsp;in&nbsp;my&nbsp;back&shy;yard.</p>
+
+        <p id="test4" class="test hyphenate4" lang="en-us">Yesterday I saw a brown cat in my backyard.</p>
+        <p id="ref4" class="ref" lang="en-us">Yes&shy;ter&shy;day I saw a brown cat in my back&shy;yard.</p>
+
+        <p id="test5" class="test hyphenate1" lang="en-us">Yesterday I saw a brown cat in my backyard. Yesterday I saw a brown cat in my backyard.</p>
+        <p id="ref5" class="ref" lang="en-us">Yes&shy;ter&shy;day I&nbsp;saw a&nbsp;brown cat in my back&shy;yard. Yes&shy;ter&shy;day I&nbsp;saw a&nbsp;brown cat in my back&shy;yard.</p>
+        <hr>
+        <div><span class="test">Test</span> <span class="ref">Ref</span></div>
+
+    </body>
+</html>

--- a/testsuite/testdriver.js
+++ b/testsuite/testdriver.js
@@ -53,7 +53,8 @@
         {"exec": true, "path": "test46.html"},
         {"exec": true, "path": "test47.html"},
         {"exec": true, "path": "test48.html"},
-        {"exec": true, "path": "test49.html"}
+        {"exec": true, "path": "test49.html"},
+        {"exec": true, "path": "test50.html"}
     ];
     var testframe = document.getElementById("testframe");
     var currentTest = 1;


### PR DESCRIPTION
feat: prevent small words and eol
    
    Problem:
    Some languages (e.g. polish) require not to have single letter words
    at the end of a line.
    
    Solution:
    Implement a optional class based setting, find small words and replace
    the space after them with a nbsp.
    This is easy if we just search for single letter words, but get somehow
    complicated when we open to any number of chars because we'll have
    handle overlapping regex matches.

fixes #139 