### PR TITLE
Added TextDecoder require to fix node version 10.x

### DIFF
--- a/hyphenopoly.module.js
+++ b/hyphenopoly.module.js
@@ -15,10 +15,12 @@
  * in a browser environment (e.g. browserified)
  */
 let loader = require("fs");
-let TextDecoder = require('util').TextDecoder;
+const TD = typeof TextDecoder === "undefined"
+    ? require("util").TextDecoder
+    : TextDecoder;
 
 const decode = (() => {
-    const utf16ledecoder = new TextDecoder("utf-16le");
+    const utf16ledecoder = new TD("utf-16le");
     return (ui16) => {
         return utf16ledecoder.decode(ui16);
     };

--- a/hyphenopoly.module.js
+++ b/hyphenopoly.module.js
@@ -15,6 +15,7 @@
  * in a browser environment (e.g. browserified)
  */
 let loader = require("fs");
+let TextDecoder = require('util').TextDecoder;
 
 const decode = (() => {
     const utf16ledecoder = new TextDecoder("utf-16le");


### PR DESCRIPTION
We found that the module.js does not support node version 10.x.
There seems to be an issue that TextDecoder is not imported and so cannot be found in that version.

The related ticket is:
https://github.com/danburzo/percollate/pull/114

Best Regards