### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -97,6 +97,10 @@
     ],
     "no-ternary": 0,
     "no-nested-ternary": 0,
+    "no-restricted-properties": [
+      "error",
+      { "property": "substr", "message": "Use .slice instead of .substr." }
+    ],
     "prefer-destructuring": 0,
     "max-params": [
       1,

--- a/tools/modules/bits.js
+++ b/tools/modules/bits.js
@@ -49,7 +49,7 @@ function bits() {
         let pos = 0;
         const bytes = [];
         while (pos < bitString.length) {
-            bytes.push(parseInt(bitString.substr(pos, 8).padEnd(8, "0"), 2));
+            bytes.push(parseInt(bitString.slice(pos, pos + 8).padEnd(8, "0"), 2));
             pos += 8;
         }
         const ret = Uint8Array.from(bytes);
@@ -61,7 +61,7 @@ function bits() {
         let pos = 0;
         const bytes = [];
         while (pos < bitString.length) {
-            bytes.push(parseInt(bitString.substr(pos, 8).padEnd(8, "0"), 2));
+            bytes.push(parseInt(bitString.slice(pos, pos + 8).padEnd(8, "0"), 2));
             pos += 8;
         }
         const swapped = [];


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.