### PR TITLE
fix: issue #205

### DIFF
--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -659,7 +659,11 @@
         H.unhyphenate = () => {
             H.res.els.list.forEach((els) => {
                 els.forEach((elo) => {
-                    elo.element.innerHTML = elo.element.innerHTML.replace(RegExp(C[elo.selector].hyphen, "g"), "");
+                    elo.element.childNodes.forEach((n) => {
+                        if (n.nodeType === 3) {
+                            n.data = n.data.replace(RegExp(C[elo.selector].hyphen, "g"), "");
+                        }
+                    });
                 });
             });
             return Promise.resolve(H.res.els);

--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -659,8 +659,7 @@
         H.unhyphenate = () => {
             H.res.els.list.forEach((els) => {
                 els.forEach((elo) => {
-                    const n = elo.element.firstChild;
-                    n.data = n.data.replace(RegExp(C[elo.selector].hyphen, "g"), "");
+                    elo.element.innerHTML = elo.element.innerHTML.replace(RegExp(C[elo.selector].hyphen, "g"), "");
                 });
             });
             return Promise.resolve(H.res.els);

--- a/testsuite/test56.html
+++ b/testsuite/test56.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+        <title>Test 056</title>
+        <script src="../Hyphenopoly_Loader.js"></script>
+        <script>
+            Hyphenopoly.config({
+                require: {
+                    "de": "FORCEHYPHENOPOLY"
+                },
+                setup: {
+                    selectors: {
+                        ".hyphenate": {
+                            hyphen: "•",
+                            minWordLength: 4
+                        }
+                    }
+                },
+                handleEvent: {
+                    hyphenopolyEnd: function (e) {
+                        Hyphenopoly.unhyphenate();
+                        assert();
+                    }
+                }
+            });
+
+            function assert() {
+                var tests = 3;
+                var i = 1;
+                var test = "";
+                var ref = "";
+                var result = true;
+                while (i <= tests) {
+                    test = document.getElementById("test" + i).innerHTML;
+                    ref = document.getElementById("ref" + i).innerHTML;
+                    if (test === ref) {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #d6ffd6\">" + i + " passed</p>";
+                        result = result && true;
+                    } else {
+                        document.getElementById("result").innerHTML += "<p style=\"background-color: #ffd6d6\">" + i + " failed</p>";
+                        result = false;
+                    }
+                    i += 1;
+                }
+                if (parent != window) {
+                    parent.postMessage(JSON.stringify({
+                        desc: document.getElementById("desc").innerHTML,
+                        index: 56,
+                        result: (result ? "passed" : "failed")
+                    }), window.location.href);
+                }
+            }
+        </script>
+        <style type="text/css">
+            body {
+                width:50%;
+                margin-left:25%;
+                margin-right:25%;
+            }
+
+            .test {
+                background-color: #D8E2F9;
+            }
+            .ref {
+                background-color: #FEEFC0;
+            }
+
+            .hyphenate {
+                hyphens: auto;
+                -ms-hyphens: auto;
+                -moz-hyphens: auto;
+                -webkit-hyphens: auto;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="navigate"><a href="index.html">&Larr;&nbsp;Index</a>&nbsp;|&nbsp;<a href="test55.html">&larr;&nbsp;Prev</a>&nbsp;|&nbsp;<a href="test57.html">Next&nbsp;&rarr;</a></div>
+
+        <h1>Test 056</h1>
+        <p id="desc">Check Hyphenopoly.unhyphenate()</p>
+        <div id="result"></div>
+        <hr>
+        <p id="test1" class="test hyphenate" lang="de">Silbentrennung</p>
+        <p id="ref1" class="ref" lang="de">Silbentrennung</p>
+        <p id="test2" class="test hyphenate" lang="de">Silbentrennung <br />Silbentrennung</p>
+        <p id="ref2" class="ref" lang="de">Silbentrennung <br />Silbentrennung</p>
+        <p id="test3" class="test hyphenate" lang="de">Silbentrennung <span>Silbentrennung</span></p>
+        <p id="ref3" class="ref" lang="de">Silbentrennung <span>Silbentrennung</span></p>
+        <hr>
+        <div><span class="test">Test</span> <span class="ref">Ref</span></div>
+
+    </body>
+</html>

--- a/testsuite/test56.html
+++ b/testsuite/test56.html
@@ -83,10 +83,10 @@
         <hr>
         <p id="test1" class="test hyphenate" lang="de">Silbentrennung</p>
         <p id="ref1" class="ref" lang="de">Silbentrennung</p>
-        <p id="test2" class="test hyphenate" lang="de">Silbentrennung <br />Silbentrennung</p>
-        <p id="ref2" class="ref" lang="de">Silbentrennung <br />Silbentrennung</p>
-        <p id="test3" class="test hyphenate" lang="de">Silbentrennung <span>Silbentrennung</span></p>
-        <p id="ref3" class="ref" lang="de">Silbentrennung <span>Silbentrennung</span></p>
+        <p id="test2" class="test hyphenate" lang="de">Silbentrennung <br />Algorithmus</p>
+        <p id="ref2" class="ref" lang="de">Silbentrennung <br />Algorithmus</p>
+        <p id="test3" class="test hyphenate" lang="de">Silbentrennung <span>Algorithmus</span></p>
+        <p id="ref3" class="ref" lang="de">Silbentrennung <span>Algorithmus</span></p>
         <hr>
         <div><span class="test">Test</span> <span class="ref">Ref</span></div>
 

--- a/testsuite/testdriver.js
+++ b/testsuite/testdriver.js
@@ -59,7 +59,8 @@
         {"exec": true, "path": "test52.html"},
         {"exec": true, "path": "test53.html"},
         {"exec": true, "path": "test54.html"},
-        {"exec": true, "path": "test55.html"}
+        {"exec": true, "path": "test55.html"},
+        {"exec": true, "path": "test56.html"}
     ];
     var testframe = document.getElementById("testframe");
     var currentTest = 1;


### PR DESCRIPTION
Problem:
Only first childNode gets unhyphenated

Solution:
call replace() on innerHTML. This should be save in this context.

Notes:
Alternatively loop over childNodes

Fixes #205, [ci skip]