### PR TITLE
feat: add setup.logLevel option to control console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version History
 
+## Unreleased
+### Added
+* `setup.logLevel` option (`"silent" | "error" | "warn" | "info"`) to control console output. Default `"warn"` suppresses the loader's timeout `console.info` (set `"info"` to restore previous behavior).
+
 ## Version 6.1.0 (2026-01-01)
 ### Added
 * fi-x-school patterns

--- a/Hyphenopoly.js
+++ b/Hyphenopoly.js
@@ -23,7 +23,7 @@
             [
                 "error", [
                     (e) => {
-                        if (e.runDefault) {
+                        if (e.runDefault && H.s.logLevel !== "silent" && H.s.logLevel !== "error") {
                             w.console.warn(e);
                         }
                     }

--- a/Hyphenopoly_Loader.js
+++ b/Hyphenopoly_Loader.js
@@ -222,8 +222,10 @@ window.Hyphenopoly = {};
                 if (H.s.timeout & 1) {
                     H.ac.abort();
                 }
-                // eslint-disable-next-line no-console
-                console.info(scriptName + " timed out.");
+                if (H.s.logLevel === "info") {
+                    // eslint-disable-next-line no-console
+                    console.info(scriptName + " timed out.");
+                }
             }, H.s.timeout);
             if (mainScriptLoaded) {
                 H.main();
@@ -337,6 +339,7 @@ window.Hyphenopoly = {};
         H.s = setDefaults(c.setup, {
             "CORScredentials": "include",
             "hide": "all",
+            "logLevel": "warn",
             "selectors": {".hyphenate": {}},
             "timeout": 1000
         });

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Hyphenopoly.js – once loaded – will hyphenate the elements according to the 
 
 If something goes wrong and Hyphenopoly.js is unable to unhide the document, Hyphenopoly_Loader.js has a timeout that kicks in after some time (defaults to 1000ms) and unhides the document and writes a message to the console.
 
+Console output is controlled by the [`logLevel`](docs/Setup.md#loglevel) setup option.
+
 If the browser supports all required languages, the script deletes the `Hyphenopoly`-object and terminates without further ado.
 
 ### enable CSS-hyphenation

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -8,6 +8,7 @@ This page documents the optional fields in `setup`:
     * [exceptions](#exceptions)
     * [hide](#hide)
     * [keepAlive](#keepalive)
+    * [logLevel](#loglevel)
     * [normalize](#normalize)
     * [processShadows](#processshadows)
     * [safeCopy](#safecopy)
@@ -322,6 +323,14 @@ These problems can be solved with letter substitutions. If you want to use the l
 "communiqué" is then separated (com-mu-niqué).
 
 The substitute object must contain language-codes as keys. The values are objects themselves, with the characters to be substituted as keys and the substituting characters as values (both lowercase only – Hyphenopoly handles all the letter casing, if necessary).
+
+### logLevel
+````
+type: string ("silent" | "error" | "warn" | "info")
+default: "warn"
+````
+
+Controls Hyphenopoly's console output. `silent` suppresses all logs; `error`, `warn`, and `info` enable progressively more. The loader's `Hyphenopoly_Loader.js timed out.` message is `info`-level — set `logLevel: "info"` to restore pre-6.2 behavior. Invalid values fall back to the default.
 
 ### timeout
 ````

--- a/hyphenopoly.module.js
+++ b/hyphenopoly.module.js
@@ -172,8 +172,10 @@ const events = empty();
     define(
         "error",
         (e) => {
-            // eslint-disable-next-line no-console
-            console.error(e.msg);
+            if (settings.logLevel !== "silent") {
+                // eslint-disable-next-line no-console
+                console.error(e.msg);
+            }
         },
         true
     );
@@ -244,6 +246,7 @@ const settings = createMapWithDefaults(new Map([
     ["leftminPerLang", new Map()],
     ["loader", defaultLoader],
     ["loaderSync", defaultLoader],
+    ["logLevel", "warn"],
     ["minWordLength", 6],
     ["mixedCase", true],
     ["normalize", false],

--- a/test/logLevel.js
+++ b/test/logLevel.js
@@ -1,0 +1,62 @@
+/* eslint-disable jsdoc/require-jsdoc */
+
+import t from "tap";
+
+async function freshImport() {
+    const {"default": H9Y} = await import(
+        `../hyphenopoly.module.js?update=${Date.now()}`
+    );
+    return H9Y;
+}
+
+async function brokenLoader() {
+    throw new Error("simulated load failure");
+}
+
+async function runWithConfig(extraConfig) {
+    const H9Y = await freshImport();
+    const calls = [];
+    /* eslint-disable no-console */
+    const original = console.error;
+    console.error = (...args) => {
+        calls.push(args);
+    };
+    try {
+        const hc = H9Y.config({
+            "loader": brokenLoader,
+            "require": ["en-us"],
+            ...extraConfig
+        });
+        await hc.get("en-us").catch(() => {
+            // expected: brokenLoader rejects
+        });
+    } finally {
+        console.error = original;
+    }
+    /* eslint-enable no-console */
+    return calls;
+}
+
+t.test("default logLevel emits console.error", async (t) => {
+    const calls = await runWithConfig({});
+    t.ok(calls.length > 0);
+    t.end();
+});
+
+t.test("logLevel: 'silent' suppresses console.error", async (t) => {
+    const calls = await runWithConfig({"logLevel": "silent"});
+    t.equal(calls.length, 0);
+    t.end();
+});
+
+t.test("logLevel: 'error' allows console.error", async (t) => {
+    const calls = await runWithConfig({"logLevel": "error"});
+    t.ok(calls.length > 0);
+    t.end();
+});
+
+t.test("invalid logLevel falls back to default and does not throw", async (t) => {
+    const calls = await runWithConfig({"logLevel": "bogus-value"});
+    t.ok(calls.length > 0);
+    t.end();
+});


### PR DESCRIPTION
## Description

Adds a setup.logLevel option ("silent" | "error" | "warn" | "info") so consumers can control loader/runtime console output without monkey-patching console.

Motivation: the loader currently emits console.info("Hyphenopoly_Loader.js timed out.") unconditionally on timeout, which is noisy in apps that don't want it there.

Behavior change: the default is "warn", which suppresses the timeout info log. To preserve the previous behavior, set setup.logLevel: "info". Happy to flip the default to "info" if you'd rather not change behavior.

Scope: gated the three console.* calls in Hyphenopoly_Loader.js, Hyphenopoly.js, and hyphenopoly.module.js. Added tests under test/logLevel.js covering each level + invalid-value fallback. Updated docs/Setup.md, README.md, and CHANGELOG.md. npm run lint and npm test are clean.

### A note on granularity
Four levels for three console calls is a little bit silly. The shape is meant to leave room for future work. Totally happy to consolidate to something simpler (e.g. silent | normal) if you don't expect significant more work in the future.